### PR TITLE
Enhance autoloading and php-version support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: php
 
 php:
+  - 7.0
   - 7.1
   - 7.2
   - nightly
@@ -11,11 +12,8 @@ matrix:
   allow_failures:
     - php: nightly
 
-before_install:
-  - composer self-update
-
 install:
-  - composer install
+  - composer update
 
 script:
   - vendor/bin/phpcs --config-set installed_paths "../../wp-coding-standards/wpcs/,../../automattic/phpcs-neutron-standard/,../../inpsyde/php-coding-standards/,../../wimg/php-compatibility/,../../pheromone/phpcs-security-audit/Security/"

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "php": ">=7"
     },
     "require-dev": {
-        "phpunit/phpunit": "6.3.*",
+        "phpunit/phpunit": "^6.3",
         "inpsyde/php-coding-standards": "^0.13",
         "antecedent/patchwork": "^2.1",
         "dg/composer-cleaner": "^2"
@@ -29,7 +29,6 @@
     },
     "autoload-dev": {
         "psr-4": {
-            "Bueltge\\Marksimple\\": "src/",
             "Bueltge\\Marksimple\\Tests\\Unit\\": "tests/phpunit/Unit/"
         }
     },


### PR DESCRIPTION
# Changed log
- According to the `composer.json`, the `php-7.0` version is still supported so it should test this PHP version in Travis CI build.
- The `composer.lock` caches the packages support the `php-7.1+` versions.
It should run `composer update` command in Travis CI build so that the `php-7.0` version will be passed in CI build work.
- The `"Bueltge\\Marksimple\\": "src/", ` definition inside `autoload-dev` block in `composer.json` is duplicated. This defines inside `autoload` block. This duplicate definition should be removed.